### PR TITLE
fix(StrictOmit): fix incorrect implementation in StrictOmit

### DIFF
--- a/docs/ko/reference/utilities/StrictOmit.md
+++ b/docs/ko/reference/utilities/StrictOmit.md
@@ -9,10 +9,10 @@
 ## 문법
 
 ```ts
-type StrictOmit<
-  ObjectType extends object,
-  ExcludedKeys extends keyof ObjectType,
-> = Pick<ObjectType, Exclude<keyof ObjectType, ExcludedKeys>>;
+type StrictOmit<ObjectType, ExcludedKeys extends keyof ObjectType> = Omit<
+  ObjectType,
+  ExcludedKeys
+>;
 ```
 
 - **ObjectType**: 속성이 생략될 타입이에요.

--- a/docs/reference/utilities/StrictOmit.md
+++ b/docs/reference/utilities/StrictOmit.md
@@ -12,10 +12,10 @@ unintended omissions of non-existent keys.
 ## Syntax
 
 ```ts
-type StrictOmit<
-  ObjectType extends object,
-  ExcludedKeys extends keyof ObjectType,
-> = Pick<ObjectType, Exclude<keyof ObjectType, ExcludedKeys>>;
+type StrictOmit<ObjectType, ExcludedKeys extends keyof ObjectType> = Omit<
+  ObjectType,
+  ExcludedKeys
+>;
 ```
 
 - **ObjectType**: The type from which properties will be omitted.

--- a/source/utilities/StrictOmit.d.ts
+++ b/source/utilities/StrictOmit.d.ts
@@ -7,7 +7,7 @@
  * This provides a more controlled and predictable type manipulation, preventing
  * unintended omissions of non-existent keys.
  *
- * @template {object} ObjectType - The type from which properties will be omitted.
+ * @template ObjectType - The type from which properties will be omitted.
  * @template ExcludedKeys - The keys to be omitted, which must be present in `ObjectType`.
  *
  * @returns
@@ -30,6 +30,6 @@
  * // Type '"noexistent"' is not assignable to type 'keyof Example'.
  */
 export type StrictOmit<
-  ObjectType extends object,
+  ObjectType,
   ExcludedKeys extends keyof ObjectType,
-> = Pick<ObjectType, Exclude<keyof ObjectType, ExcludedKeys>>;
+> = Omit<ObjectType, ExcludedKeys>;


### PR DESCRIPTION
This PR fixes the `StrictOmit` type by simplifying its implementation and removing the unncessary `extends object` constant. 

The previous implementation used `Pick` and `Exclude`, which was more complex. The updated implementation utilizes TypeScript built-in `Omit` type for a more straightforward and intuitive approach. 

Removing the `extends object` costraint aligns with TypeScript's latest standards, ensuring broader compatibility and maintaining consistency with TypeScript's built-in utility types. This change enhances code clarity and maintainability.